### PR TITLE
adapt jdk-8350443

### DIFF
--- a/.github/scripts/test-openjdk-pullrequests.py
+++ b/.github/scripts/test-openjdk-pullrequests.py
@@ -747,7 +747,7 @@ def cleanup_closed_prs():
             # Can fail if other commits were pushed in between
             info("pushing test record deletion failed", COLOR_WARN)
 
-def get_pr_to_test(untested_prs, visited):
+def get_pr_to_test(untested_prs, failed_pull_requests, visited):
     """
     Finds an upstream PR with an existing artifact that should be tested.
 
@@ -836,7 +836,7 @@ def get_pr_to_test(untested_prs, visited):
                             if not (os.path.isdir("extracted") and os.listdir("extracted")):
                                 # Check if pr is pre JDK-8350443, i.e., with static libs bundled with the same zip
                                 if not any((zi.filename.startswith("static-libs") for zi in zf.infolist())):
-                                    untested_prs.setdefault("they are missing the static-libs bundle (added by JDK-8337265)", []).append(pr)
+                                    failed_pull_requests.append(pr)
                                     continue
 
                             for zi in zf.infolist():
@@ -870,7 +870,7 @@ def main():
 
     visited = set()
     while True:
-        pr, artifact = get_pr_to_test(untested_prs, visited)
+        pr, artifact = get_pr_to_test(untested_prs, failed_pull_requests, visited)
         if not pr:
             break
 

--- a/.github/scripts/test-openjdk-pullrequests.py
+++ b/.github/scripts/test-openjdk-pullrequests.py
@@ -801,8 +801,8 @@ def get_pr_to_test(untested_prs, visited):
         # Search runs for non-expired artifact
         for run in runs["workflow_runs"]:
             run_id = run["id"]
+            # With JDK-8350443, static libs bundle is uploaded in bundles-linux-x64-static
             artifacts_obj_static = gh_api(["--paginate", f"/repos/{repo}/actions/runs/{run_id}/artifacts?name={_artifact_to_test}-static"])
-
             for artifact in artifacts_obj_static["artifacts"]:
                 if not artifact["expired"]:
                     # Download artifact
@@ -820,12 +820,7 @@ def get_pr_to_test(untested_prs, visited):
 
                     break
 
-            if not (os.path.isdir("extracted") and os.listdir("extracted")):
-                untested_prs.setdefault("they are missing the static-libs bundle (added by JDK-8337265, JDK-8350443)", []).append(pr)
-                continue
-
             artifacts_obj = gh_api(["--paginate", f"/repos/{repo}/actions/runs/{run_id}/artifacts?name={_artifact_to_test}"])
-
             for artifact in artifacts_obj["artifacts"]:
                 if not artifact["expired"]:
 
@@ -835,12 +830,18 @@ def get_pr_to_test(untested_prs, visited):
                     with open(archive, 'wb') as fp:
                         gh_api([f"/repos/{repo}/actions/artifacts/{artifact_id}/zip"], stdout=fp)
 
-                    # Extract JDK
+                    # Extract JDK and static-libs bundles
                     try:
                         with zipfile.ZipFile(archive, 'r') as zf:
+                            if not (os.path.isdir("extracted") and os.listdir("extracted")):
+                                # Check if pr is pre JDK-8350443, i.e., with static libs bundled with the same zip
+                                if not any((zi.filename.startswith("static-libs") for zi in zf.infolist())):
+                                    untested_prs.setdefault("they are missing the static-libs bundle (added by JDK-8337265)", []).append(pr)
+                                    continue
+
                             for zi in zf.infolist():
                                 filename = zi.filename
-                                if filename.endswith(".tar.gz") and filename.startswith("jdk-"):
+                                if filename.endswith(".tar.gz") and (filename.startswith("jdk-") or filename.startswith("static-libs")):
                                     zf.extract(filename)
                                     with tarfile.open(filename, "r:gz") as tf:
                                         tf.extractall(path="extracted", filter="fully_trusted")

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Details
 The [test-openjdk-pullrequests](.github/scripts/test-openjdk-pullrequests.py) script uses the
 [GitHub REST API](https://docs.github.com/en/rest) to periodically poll the open, non-draft
 pull requests at https://github.com/openjdk/jdk/pulls. For each pull request:
-* If there is a `bundles-linux-x64` artifact available, continue.
-* Download the `bundles-linux-x64` artifact and extract the `jdk` and `static-libs` bundles.
+* If there are a `bundles-linux-x64-static` artifact and a `bundles-linux-x64` artifact available, continue.
+* Download the `bundles-linux-x64-static` artifact and extract.
+* Download the `bundles-linux-x64` artifact and extract the `jdk` bundle.
 * Set `JAVA_HOME` to the base directory of the extracted bundles.
 * Clone [graal](https://github.com/oracle/graal) and [mx](https://github.com/graalvm/mx).
 * Checkout the `galahad` branch in `graal` and `mx`.


### PR DESCRIPTION
With https://github.com/openjdk/jdk/pull/23715, static libs is now stored in a separate location