### PR TITLE
Disable DaCapo

### DIFF
--- a/.github/scripts/test-openjdk-pullrequests.py
+++ b/.github/scripts/test-openjdk-pullrequests.py
@@ -453,7 +453,8 @@ def test_pull_request(pr, artifact, failed_pull_requests):
                 "LibGraal Compiler:FatalErrorHandling",
                 "LibGraal Compiler:SystemicFailureDetection",
                 "LibGraal Compiler:CTW",
-                "LibGraal Compiler:DaCapo"
+                # DaCapo 23.11-MR2-chopin is too large to host on GitHub action
+                # "LibGraal Compiler:DaCapo"
             ]
             run_step("test", ["mx/mx", "-p", "graal/vm", "--java-home", java_home, "--env", "libgraal", "gate", "--task", ','.join(tasks)])
 


### PR DESCRIPTION
Currently canary is failing with  
```
[Errno 28] No space left on device
```
when running DaCapo. This is likely due to https://github.com/oracle/graal/commit/202c958a6938c85acb250c7eccc3bb28c181e812